### PR TITLE
Return 0 instead of 1 when printing help text

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -41,7 +41,7 @@ int main(int argc, char **argv) {
 
   if (vm.count("help")) {
     std::cout << desc << std::endl;
-    return 1;
+    return 0;
   }
 
   std::string conf_path = vm["config"].as<std::string>();


### PR DESCRIPTION
It makes no sense to return 1 (error) when printing the help text
