### PR TITLE
Send ping as en event, and not a "comment"

### DIFF
--- a/src/SSEChannel.cpp
+++ b/src/SSEChannel.cpp
@@ -337,7 +337,7 @@ void SSEChannel::CleanupMain() {
 */
 void SSEChannel::Ping() {
   while(!stop) {
-    Broadcast(":\n\n");
+    Broadcast("event:ping\n\n");
     sleep(_config.server->GetValueInt("server.pingInterval"));
   }
 }


### PR DESCRIPTION
If we send ping as en event it's possible to pick it up in the client and handle reconnect, refetching etc. if we haven't received a ping in X seconds.
