### PR TITLE
Log a warning when parsing of the config file has failed

### DIFF
--- a/src/SSEConfig.cpp
+++ b/src/SSEConfig.cpp
@@ -70,7 +70,9 @@ bool SSEConfig::load(const char *file) {
   // Read config file.
   try {
     boost::property_tree::read_json(file, pt);
-  } catch (...) {}
+  } catch (boost::property_tree::ptree_error& e) {
+    LOG(WARNING) << "Error during loading config file: " << e.what();
+  }
 
   // Populate ConfigMap.
   BOOST_FOREACH(ConfigMap_t::value_type &element, ConfigMap) {

--- a/src/SSEConfig.cpp
+++ b/src/SSEConfig.cpp
@@ -71,7 +71,7 @@ bool SSEConfig::load(const char *file) {
   try {
     boost::property_tree::read_json(file, pt);
   } catch (boost::property_tree::ptree_error& e) {
-    LOG(WARNING) << "Error during loading config file: " << e.what();
+    LOG(FATAL) << "Error during loading config file: " << e.what();
   }
 
   // Populate ConfigMap.


### PR DESCRIPTION
The current behaviour is counterintuitive. The config is silently ignored without any message when there is JSON parse error.
So I added a warning, but one can still omit the config file to use the default configuration.